### PR TITLE
Update restrictions-users.conf

### DIFF
--- a/SOURCES/restrictions-users.conf
+++ b/SOURCES/restrictions-users.conf
@@ -4,9 +4,9 @@ location ~ ^/(favicon|apple-touch-icon|browserconfig|mstile)(.*)\.(png|xml|ico)$
 }
 
 location = /robots.txt {
-	allow all;
-	log_not_found off;
-	access_log off;
+    try_files $uri $uri/ /index.php?$args;
+    access_log off;
+    log_not_found off;
 }
 
 location ~ /\. {


### PR DESCRIPTION
Robots.txt is giving a 404:
https://medium.com/@oktay.acikalin/wordpress-nginx-virtual-robots-txt-and-404-bd5cc082725d

same would be neccesary in the restrictions.conf file